### PR TITLE
Deleting and editing a session works. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
               {{#if twosessions}}
               <div class="col-md-5">
                 <div class="track1Event panel-body" id="{{sessions.0.id}}">
-                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession(this.parentNode.id)">
+                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession({{@../index}},{{@index}},0)">
                     <label data-toggle="tooltip" title="Edit the session" data-placement="top" data-trigger="hover">
                       <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                     </label>
@@ -222,7 +222,7 @@
               </div>
               <div class="col-md-5">
                 <div class="panel-body track2Event" id="{{sessions.1.id}}">
-                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession(this.parentNode.id)">
+                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession({{@../index}},{{@index}},1)">
                     <label data-toggle="tooltip" title="Edit the session" data-placement="top" data-trigger="hover">
                       <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                     </label>
@@ -260,7 +260,7 @@
               {{else}} <!-- One session -->
               <div class="col-md-10">
                 <div class="panel-body mutualEvent" id="{{sessions.0.id}}">
-                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession(this.parentNode.id)">
+                  <a data-toggle="modal" href="#editSessionBox" class="pull-right" onclick="editSession({{@../index}},{{@index}},0)">
                     <label data-toggle="tooltip" title="Edit the session" data-placement="top" data-trigger="hover">
                       <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
                     </label>
@@ -482,8 +482,10 @@
           </div>
           <div class="modal-body">
             <form>
-              <!-- NOTE: used only for saving edited session to progData -->
-              <input type="hidden" id="currentSessionId" value="" />
+              <!-- NOTE: These are used to look up the session that is being edited. -->
+              <input type="hidden" id="currentDayIndex" value="" />
+              <input type="hidden" id="currentSlotIndex" value="" />
+              <input type="hidden" id="currentSessionIndex" value="" />
               <div class="form-group">
                 <label for="sessionTitle">
                   Session Title


### PR DESCRIPTION
Also fixed a bug when the startTime of a timeslot was changed - we needed to re-sort the timeslots in that day. We no longer look up sessions by id - the id for a session is the (dayIndex, slotIndex, sessionIndex) indices into the arrays of days, timeslots, and sessions. This makes it easier to delete a session from the array that holds it.