### PR TITLE
No need to escape things from mysql any more since we use

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -125,10 +125,6 @@ function doGetRow($pdo, $id) {
     return;
   }
   $json = $row['json'];
-  // The process of storing them seems to escape single and double quotes.
-  // We need to understand this better.
-  $json = str_replace('\"', '"', $json);
-  $json = str_replace("\\'", "'", $json);
   echo $json;
 }
 

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -162,8 +162,9 @@ function getConfig(name, existing) {
     $('#templateSelector').hide();
     $('#nameEntry').show(500);
   })
-  .fail(function(jqxhr, textStatus, error) {
-    warningBox('There was a problem with this conference template. Please try another.');
+    .fail(function(jqxhr, textStatus, error) {
+      console.dir(jqxhr);
+      warningBox('There was a problem with this conference template. Please try another.');
   });
 }
 


### PR DESCRIPTION
prepared statements. Also log better in the client when json
cannot be parsed.