### PR TITLE
Fix the JSON example for talk uploading

### DIFF
--- a/docs/help.html
+++ b/docs/help.html
@@ -70,7 +70,7 @@
   {
     "title": "New Directions in Cryptography",
     "authors": "Whitfield Diffie and Martin E.Hellman",
-    "affiliations": "Stanford University"
+    "affiliations": "Stanford University",
     "category": "Public Key Cryptography"
   }
 ]}</pre>


### PR DESCRIPTION
Missing comma after `"affiliations": "Stanford University"`