### PR TITLE
Fix issue #115 where if only manually entered talks are used, the

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
             <button type="button" name="showUpload" onclick="showWebsubrevUpload()" class="btn btn-sm btn-success">
               Upload websubrev accepted talks
             </button>
-            <button type="button" name="skipUpload" onclick="startEditor()" class="btn btn-sm btn-success">
+            <button type="button" name="skipUpload" onclick="useEmptyTalks()" class="btn btn-sm btn-success">
               Skip for now
             </button>
             <button type="button" name="useDemoTalks" onclick="useDemoTalks()" class="btn btn-sm btn-success">

--- a/scripts/editor.js
+++ b/scripts/editor.js
@@ -234,6 +234,11 @@ function useDemoTalks() {
   });
 }
 
+function useEmptyTalks() {
+  progData.config.unassigned_talks = [{'name': 'Uncategorized', 'talks':[], 'id': 'category-0'}];
+  startEditor();
+}
+
 // Upload JSON file of talks and parse.
 function uploadTalks(evt) {
   var files = evt.target.files;


### PR DESCRIPTION
talk assignments do not get saved. This was caused by having no id
on the Uncategorized category, so that findObj() could not find the
appropriate category because the parent div had no id.